### PR TITLE
Complete Tags API Support

### DIFF
--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -148,6 +148,17 @@ class Zeppelin
     successful?(response) ? parse(response.body) : nil
   end
 
+  # Modifies device tokens associated with a tag.
+  #
+  # @param [String] tag The name of the tag to modify tag associations on
+  #
+  # @param [Hash] payload
+  #
+  # @see http://urbanairship.com/docs/tags.html#modifying-device-tokens-on-a-tag
+  def modify_device_tokens_on_tag(tag_name, payload = {})
+    @connection.post(tag_uri(tag_name), payload, JSON_HEADERS)
+  end
+
   # Creates a tag that is not associated with any device
   #
   # @param [#to_s] name The name of the tag to add

--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -171,6 +171,14 @@ class Zeppelin
 
   # @param [String] device_token
   #
+  # @return [Hash, nil]
+  def device_tags(device_token)
+    response = @connection.get(device_tag_uri(device_token, nil))
+    successful?(response) ? parse(response.body) : nil
+  end
+
+  # @param [String] device_token
+  #
   # @param [#to_s] tag_name
   #
   # @return [Boolean] whether or not a tag was successfully associated with

--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -140,6 +140,14 @@ class Zeppelin
     successful?(response) ? Yajl::Parser.parse(response.body) : nil
   end
 
+  # Retrieve all tags on the service
+  #
+  # @return [Hash, nil]
+  def tags
+    response = @connection.get(tag_uri(nil))
+    successful?(response) ? Yajl::Parser.parse(response.body) : nil
+  end
+
   # Creates a tag that is not associated with any device
   #
   # @param [#to_s] name The name of the tag to add

--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -55,7 +55,7 @@ class Zeppelin
   # @return [Hash, nil]
   def device_token(device_token)
     response = @connection.get(device_token_uri(device_token))
-    successful?(response) ? Yajl::Parser.parse(response.body) : nil
+    successful?(response) ? parse(response.body) : nil
   end
   
   # Deletes a device token.
@@ -90,7 +90,7 @@ class Zeppelin
   # @return [Hash, nil]
   def apid(apid)
     response = @connection.get(apid_uri(apid))
-    successful?(response) ? Yajl::Parser.parse(response.body) : nil
+    successful?(response) ? parse(response.body) : nil
   end
   
   # Deletes an APID.
@@ -137,7 +137,7 @@ class Zeppelin
   # @return [Hash, nil]
   def feedback(since)
     response = @connection.get(feedback_uri(since))
-    successful?(response) ? Yajl::Parser.parse(response.body) : nil
+    successful?(response) ? parse(response.body) : nil
   end
 
   # Retrieve all tags on the service
@@ -145,7 +145,7 @@ class Zeppelin
   # @return [Hash, nil]
   def tags
     response = @connection.get(tag_uri(nil))
-    successful?(response) ? Yajl::Parser.parse(response.body) : nil
+    successful?(response) ? parse(response.body) : nil
   end
 
   # Creates a tag that is not associated with any device
@@ -215,6 +215,10 @@ class Zeppelin
   
   def successful?(response)
     SUCCESSFUL_STATUS_CODES.include?(response.status)
+  end
+
+  def parse(json)
+    Yajl::Parser.parse(json)
   end
 end
 

--- a/test/zeppelin_test.rb
+++ b/test/zeppelin_test.rb
@@ -304,6 +304,19 @@ class ZeppelinTest < Zeppelin::TestCase
     assert_nil response
   end
 
+  test '#tags' do
+    response_body = { 'tags' => ['green', 'eggs'] }
+
+    stub_requests @client.connection do |stub|
+      stub.get('/api/tags/') do
+        [200, {}, Yajl::Encoder.encode(response_body)]
+      end
+    end
+
+    response = @client.tags
+    assert_equal response_body, response
+  end
+
   test '#add_tag' do
     tag_name = 'chunky.bacon'
 

--- a/test/zeppelin_test.rb
+++ b/test/zeppelin_test.rb
@@ -317,6 +317,20 @@ class ZeppelinTest < Zeppelin::TestCase
     assert_equal response_body, response
   end
 
+  test '#modify_device_token_on_tag' do
+    tag_name = 'jimmy.page'
+    device_token = 'CAFEBABE'
+
+    stub_requests @client.connection do |stub|
+      stub.post("/api/tags/#{tag_name}") do
+        [200, {}, 'OK']
+      end
+    end
+
+    response = @client.modify_device_tokens_on_tag(tag_name, { 'device_tokens' => { 'add' => [device_token] } })
+    assert response
+  end
+
   test '#add_tag' do
     tag_name = 'chunky.bacon'
 

--- a/test/zeppelin_test.rb
+++ b/test/zeppelin_test.rb
@@ -356,6 +356,33 @@ class ZeppelinTest < Zeppelin::TestCase
     refute response
   end
 
+  test '#device_tags with existing device' do
+    device_token = 'CAFEBABE'
+    response_body = { 'tags' => ['tag1', 'some_tag'] }
+
+    stub_requests @client.connection do |stub|
+      stub.get("/api/device_tokens/#{device_token}/tags/") do
+        [200, {}, Yajl::Encoder.encode(response_body)]
+      end
+    end
+
+    response = @client.device_tags(device_token)
+    assert_equal response_body, response
+  end
+
+  test '#device_tags with non-existant device' do
+    device_token = 'CAFEBABE'
+
+    stub_requests @client.connection do |stub|
+      stub.get("/api/device_tokens/#{device_token}/tags/") do
+        [404, {}, 'Not Found']
+      end
+    end
+
+    response = @client.device_tags(device_token)
+    refute response
+  end
+
   test '#add_tag_to_device' do
     tag_name = 'radio.head'
     device_token = 'CAFEBABE'


### PR DESCRIPTION
Here it is.

I'm not entirely happy with the interface for `Zeppelin#modify_device_tokens_on_tag`. It leaves a lot of work in the hands of the user, work that could probably be wrapped up in a mini-DSL or something. Thoughts?
