### PR TITLE
Refactor Response Handling

### DIFF
--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -3,7 +3,7 @@ require 'yajl'
 require 'time'
 
 # A very tiny Urban Airship Push Notification API client.
-# 
+#
 # Provides thin wrappers around API calls to the most common API tasks. For more
 # information on how the requests and responses are formatted, visit the [Urban
 # Airship Push Notification API docs](http://urbanairship.com/docs/push.html).
@@ -14,12 +14,12 @@ class Zeppelin
   BROADCAST_URI = '/api/push/broadcast/'
   SUCCESSFUL_STATUS_CODES = (200..299)
   JSON_HEADERS = { 'Content-Type' => 'application/json' }
-  
+
   # The connection to `https://go.urbanairship.com`.
   attr_reader :connection
-  
+
   # Creates a new client.
-  # 
+  #
   # @param [String] application_key your Urban Airship Application Key
   # @param [String] application_master_secret your Urban Airship Application
   #   Master Secret
@@ -28,111 +28,111 @@ class Zeppelin
       builder.request :json
       builder.adapter :net_http
     end
-    
+
     @connection.basic_auth(application_key, application_master_secret)
   end
-  
+
   # Registers a device token.
-  # 
+  #
   # @param [String] device_token
   # @param [Hash] payload the payload to send during registration
   # @return [Boolean] whether or not the registration was successful
   def register_device_token(device_token, payload = {})
     uri = device_token_uri(device_token)
-    
+
     if payload.empty?
       response = @connection.put(uri)
     else
       response = @connection.put(uri, payload, JSON_HEADERS)
     end
-    
+
     successful?(response)
   end
-  
+
   # Retrieves information on a device token.
-  # 
+  #
   # @param [String] device_token
   # @return [Hash, nil]
   def device_token(device_token)
     response = @connection.get(device_token_uri(device_token))
     successful?(response) ? parse(response.body) : nil
   end
-  
+
   # Deletes a device token.
-  # 
+  #
   # @param [String] device_token
   # @return [Boolean] whether or not the deletion was successful
   def delete_device_token(device_token)
     response = @connection.delete(device_token_uri(device_token))
     successful?(response)
   end
-  
+
   # Registers an APID.
-  # 
+  #
   # @param [String] apid
   # @param [Hash] payload the payload to send during registration
   # @return [Boolean] whether or not the registration was successful
   def register_apid(apid, payload = {})
     uri = apid_uri(apid)
-    
+
     if payload.empty?
       response = @connection.put(uri)
     else
       response = @connection.put(uri, payload, JSON_HEADERS)
     end
-    
+
     successful?(response)
   end
-  
+
   # Retrieves information on an APID.
-  # 
+  #
   # @param [String] apid
   # @return [Hash, nil]
   def apid(apid)
     response = @connection.get(apid_uri(apid))
     successful?(response) ? parse(response.body) : nil
   end
-  
+
   # Deletes an APID.
-  # 
+  #
   # @param [String] apid
   # @return [Boolean] whether or not the deletion was successful
   def delete_apid(apid)
     response = @connection.delete(apid_uri(apid))
     successful?(response)
   end
-  
+
   # Pushes a message.
-  # 
+  #
   # @param [Hash] payload the payload of the message
   # @return [Boolean] whether or not pushing the message was successful
   def push(payload)
     response = @connection.post(PUSH_URI, payload, JSON_HEADERS)
     successful?(response)
   end
-  
+
   # Batch pushes multiple messages.
-  # 
+  #
   # @param [<Hash>] payload the payloads of each message
   # @return [Boolean] whether or not pushing the messages was successful
   def batch_push(*payload)
     response = @connection.post(BATCH_PUSH_URI, payload, JSON_HEADERS)
     successful?(response)
   end
-  
+
   # Broadcasts a message.
-  # 
+  #
   # @param [Hash] payload the payload of the message
   # @return [Boolean] whether or not broadcasting the message was successful
   def broadcast(payload)
     response = @connection.post(BROADCAST_URI, payload, JSON_HEADERS)
     successful?(response)
   end
-  
+
   # Retrieves feedback on device tokens.
-  # 
+  #
   # This is useful for removing inactive device tokens for the database.
-  # 
+  #
   # @param [Time] since the time to retrieve inactive tokens from
   # @return [Hash, nil]
   def feedback(since)
@@ -209,17 +209,17 @@ class Zeppelin
     response = @connection.delete(device_tag_uri(device_token, tag_name))
     successful?(response)
   end
-  
+
   private
-  
+
   def device_token_uri(device_token)
     "/api/device_tokens/#{device_token}"
   end
-  
+
   def apid_uri(apid)
     "/api/apids/#{apid}"
   end
-  
+
   def feedback_uri(since)
     "/api/device_tokens/feedback/?since=#{since.utc.iso8601}"
   end
@@ -231,7 +231,7 @@ class Zeppelin
   def device_tag_uri(device_token, tag_name)
     device_token_uri(device_token) + "/tags/#{tag_name}"
   end
-  
+
   def successful?(response)
     SUCCESSFUL_STATUS_CODES.include?(response.status)
   end

--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -12,7 +12,6 @@ class Zeppelin
   PUSH_URI = '/api/push/'
   BATCH_PUSH_URI = '/api/push/batch/'
   BROADCAST_URI = '/api/push/broadcast/'
-  SUCCESSFUL_STATUS_CODES = (200..299)
   JSON_HEADERS = { 'Content-Type' => 'application/json' }
 
   # The connection to `https://go.urbanairship.com`.
@@ -46,7 +45,7 @@ class Zeppelin
       response = @connection.put(uri, payload, JSON_HEADERS)
     end
 
-    successful?(response)
+    response.success?
   end
 
   # Retrieves information on a device token.
@@ -55,7 +54,7 @@ class Zeppelin
   # @return [Hash, nil]
   def device_token(device_token)
     response = @connection.get(device_token_uri(device_token))
-    successful?(response) ? parse(response.body) : nil
+    response.success? ? parse(response.body) : nil
   end
 
   # Deletes a device token.
@@ -64,7 +63,7 @@ class Zeppelin
   # @return [Boolean] whether or not the deletion was successful
   def delete_device_token(device_token)
     response = @connection.delete(device_token_uri(device_token))
-    successful?(response)
+    response.success?
   end
 
   # Registers an APID.
@@ -81,7 +80,7 @@ class Zeppelin
       response = @connection.put(uri, payload, JSON_HEADERS)
     end
 
-    successful?(response)
+    response.success?
   end
 
   # Retrieves information on an APID.
@@ -90,7 +89,7 @@ class Zeppelin
   # @return [Hash, nil]
   def apid(apid)
     response = @connection.get(apid_uri(apid))
-    successful?(response) ? parse(response.body) : nil
+    response.success? ? parse(response.body) : nil
   end
 
   # Deletes an APID.
@@ -99,7 +98,7 @@ class Zeppelin
   # @return [Boolean] whether or not the deletion was successful
   def delete_apid(apid)
     response = @connection.delete(apid_uri(apid))
-    successful?(response)
+    response.success?
   end
 
   # Pushes a message.
@@ -108,7 +107,7 @@ class Zeppelin
   # @return [Boolean] whether or not pushing the message was successful
   def push(payload)
     response = @connection.post(PUSH_URI, payload, JSON_HEADERS)
-    successful?(response)
+    response.success?
   end
 
   # Batch pushes multiple messages.
@@ -117,7 +116,7 @@ class Zeppelin
   # @return [Boolean] whether or not pushing the messages was successful
   def batch_push(*payload)
     response = @connection.post(BATCH_PUSH_URI, payload, JSON_HEADERS)
-    successful?(response)
+    response.success?
   end
 
   # Broadcasts a message.
@@ -126,7 +125,7 @@ class Zeppelin
   # @return [Boolean] whether or not broadcasting the message was successful
   def broadcast(payload)
     response = @connection.post(BROADCAST_URI, payload, JSON_HEADERS)
-    successful?(response)
+    response.success?
   end
 
   # Retrieves feedback on device tokens.
@@ -137,7 +136,7 @@ class Zeppelin
   # @return [Hash, nil]
   def feedback(since)
     response = @connection.get(feedback_uri(since))
-    successful?(response) ? parse(response.body) : nil
+    response.success? ? parse(response.body) : nil
   end
 
   # Retrieve all tags on the service
@@ -145,7 +144,7 @@ class Zeppelin
   # @return [Hash, nil]
   def tags
     response = @connection.get(tag_uri(nil))
-    successful?(response) ? parse(response.body) : nil
+    response.success? ? parse(response.body) : nil
   end
 
   # Modifies device tokens associated with a tag.
@@ -166,7 +165,7 @@ class Zeppelin
   # @return [Boolean] whether or not the request was successful
   def add_tag(name)
     response = @connection.put(tag_uri(name))
-    successful?(response)
+    response.success?
   end
 
   # Removes a tag from the service
@@ -177,7 +176,7 @@ class Zeppelin
   #   method will return false if the tag has already been removed.
   def remove_tag(name)
     response = @connection.delete(tag_uri(name))
-    successful?(response)
+    response.success?
   end
 
   # @param [String] device_token
@@ -185,7 +184,7 @@ class Zeppelin
   # @return [Hash, nil]
   def device_tags(device_token)
     response = @connection.get(device_tag_uri(device_token, nil))
-    successful?(response) ? parse(response.body) : nil
+    response.success? ? parse(response.body) : nil
   end
 
   # @param [String] device_token
@@ -196,7 +195,7 @@ class Zeppelin
   #   a device
   def add_tag_to_device(device_token, tag_name)
     response = @connection.put(device_tag_uri(device_token, tag_name))
-    successful?(response)
+    response.success?
   end
 
   # @param [String] device_token
@@ -207,7 +206,7 @@ class Zeppelin
   #   a device
   def remove_tag_from_device(device_token, tag_name)
     response = @connection.delete(device_tag_uri(device_token, tag_name))
-    successful?(response)
+    response.success?
   end
 
   private
@@ -230,10 +229,6 @@ class Zeppelin
 
   def device_tag_uri(device_token, tag_name)
     device_token_uri(device_token) + "/tags/#{tag_name}"
-  end
-
-  def successful?(response)
-    SUCCESSFUL_STATUS_CODES.include?(response.status)
   end
 
   def parse(json)

--- a/lib/zeppelin.rb
+++ b/lib/zeppelin.rb
@@ -1,5 +1,4 @@
 require 'faraday'
-require 'yajl'
 require 'time'
 
 # A very tiny Urban Airship Push Notification API client.
@@ -214,6 +213,8 @@ class Zeppelin
     conn = Faraday::Connection.new(BASE_URI, @options) do |builder|
       builder.request :json
 
+      builder.use Zeppelin::JsonParserMiddleware
+
       builder.adapter :net_http
     end
 
@@ -241,10 +242,7 @@ class Zeppelin
   def device_tag_uri(device_token, tag_name)
     device_token_uri(device_token) + "/tags/#{tag_name}"
   end
-
-  def parse(json)
-    Yajl::Parser.parse(json)
-  end
 end
 
+require 'zeppelin/json_parser_middleware'
 require 'zeppelin/version'

--- a/lib/zeppelin/json_parser_middleware.rb
+++ b/lib/zeppelin/json_parser_middleware.rb
@@ -1,0 +1,35 @@
+require 'yajl'
+
+class Zeppelin
+  # Middleware for Faraday that parses JSON response bodies. Based on code in
+  # the FaradayMiddleware project.
+  #
+  # @private
+  class JsonParserMiddleware < Faraday::Middleware
+    CONTENT_TYPE = 'Content-Type'
+
+    def initialize(app=nil)
+      @app = app
+    end
+
+    def call(env)
+      @app.call(env).on_complete do
+        parse_response(env) if process_content_type?(env) && parse_response?(env)
+      end
+    end
+
+    private
+
+    def parse_response(env)
+      env[:body] = Yajl::Parser.parse(env[:body])
+    end
+
+    def process_content_type?(env)
+      env[:response_headers][CONTENT_TYPE].to_s =~ /\bjson$/
+    end
+
+    def parse_response?(env)
+      env[:body].respond_to? :to_str
+    end
+  end
+end

--- a/test/json_parser_middleware_test.rb
+++ b/test/json_parser_middleware_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+
+class JsonParserMiddlewareTest < Zeppelin::TestCase
+  def setup
+    @json_body = "{\"foo\":\"bar\"}"
+    @expected_parsed_body = { 'foo' => 'bar' }
+  end
+
+  test 'parses a standard JSON content type' do
+    assert_equal @expected_parsed_body, process(@json_body, 'application/json').body
+  end
+
+  test 'parses vendor JSON content type' do
+    assert_equal @expected_parsed_body, process(@json_body, 'application/vnd.urbanairship+json').body
+  end
+
+  test 'does not change nil body' do
+    assert process(nil).body.nil?
+  end
+
+  test 'does not parse non-JSON content types' do
+    assert_equal '<hello>world</hello>', process('<hello>world</hello>', 'text/xml').body
+  end
+
+  def process(body, content_type=nil, options={})
+    env = { :body => body, :response_headers => Faraday::Utils::Headers.new }
+    env[:response_headers]['content-type'] = content_type if content_type
+
+    middleware = Zeppelin::JsonParserMiddleware.new(
+      lambda { |env| Faraday::Response.new(env) }
+    )
+
+    middleware.call(env)
+  end
+end

--- a/test/zeppelin_test.rb
+++ b/test/zeppelin_test.rb
@@ -70,7 +70,7 @@ class ZeppelinTest < Zeppelin::TestCase
     response_body = { 'foo' => 'bar' }
     stub_requests @client.connection do |stub|
       stub.get("/api/device_tokens/#{@device_token}") do
-        [200, {}, Yajl::Encoder.encode(response_body)]
+        [200, { 'Content-Type' => 'application/json' }, Yajl::Encoder.encode(response_body)]
       end
     end
     
@@ -160,7 +160,7 @@ class ZeppelinTest < Zeppelin::TestCase
     response_body = { 'foo' => 'bar' }
     stub_requests @client.connection do |stub|
       stub.get("/api/apids/#{@apid}") do
-        [200, {}, Yajl::Encoder.encode(response_body)]
+        [200, { 'Content-Type' => 'application/json' }, Yajl::Encoder.encode(response_body)]
       end
     end
     
@@ -289,7 +289,7 @@ class ZeppelinTest < Zeppelin::TestCase
     
     stub_requests @client.connection do |stub|
       stub.get('/api/device_tokens/feedback/?since=1970-01-01T00%3A00%3A00Z') do
-        [200, {}, Yajl::Encoder.encode(response_body)]
+        [200, { 'Content-Type' => 'application/json' }, Yajl::Encoder.encode(response_body)]
       end
     end
     
@@ -315,7 +315,7 @@ class ZeppelinTest < Zeppelin::TestCase
 
     stub_requests @client.connection do |stub|
       stub.get('/api/tags/') do
-        [200, {}, Yajl::Encoder.encode(response_body)]
+        [200, { 'Content-Type' => 'application/json' }, Yajl::Encoder.encode(response_body)]
       end
     end
 
@@ -382,7 +382,7 @@ class ZeppelinTest < Zeppelin::TestCase
 
     stub_requests @client.connection do |stub|
       stub.get("/api/device_tokens/#{device_token}/tags/") do
-        [200, {}, Yajl::Encoder.encode(response_body)]
+        [200, { 'Content-Type' => 'application/json' }, Yajl::Encoder.encode(response_body)]
       end
     end
 

--- a/test/zeppelin_test.rb
+++ b/test/zeppelin_test.rb
@@ -12,6 +12,7 @@ class ZeppelinTest < Zeppelin::TestCase
     assert_equal 'go.urbanairship.com', @client.connection.host
     assert_includes @client.connection.builder.handlers, Faraday::Adapter::NetHttp
     assert_includes @client.connection.builder.handlers, Faraday::Request::JSON
+    assert_includes @client.connection.builder.handlers, Zeppelin::JsonParserMiddleware
     assert_equal 'Basic YXBwIGtleTphcHAgbWFzdGVyIHNlY3JldA==', @client.connection.headers['Authorization']
   end
   

--- a/zeppelin.gemspec
+++ b/zeppelin.gemspec
@@ -11,17 +11,17 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/CapnKernul/zeppelin'
   s.summary     = %q{Urban Airship library for Ruby}
   s.description = %q{Ruby client for the Urban Airship Push Notification API}
-  
+
   s.rubyforge_project = 'zeppelin'
-  
+
   s.add_dependency 'faraday'
   s.add_dependency 'yajl-ruby'
-  
+
   s.add_development_dependency 'minitest', '~> 2.0'
   s.add_development_dependency 'journo'
   s.add_development_dependency 'mocha'
   s.add_development_dependency 'test_declarative'
-  
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
This commit leverages the facilities in Faraday to simplify response handling. Namely it removes the redundant `#successful?` method, and introduces an intelligent Faraday middleware to parse JSON response bodies.
