### PR TITLE
Update README  and gemspec with correct links to repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# zeppelin - Urban Airship library for Ruby [![StillMaintained Status](http://stillmaintained.com/CapnKernul/zeppelin.png)](http://stillmaintained.com/CapnKernul/zeppelin) [![Build Status](https://travis-ci.org/CapnKernul/zeppelin.png)](https://travis-ci.org/CapnKernul/zeppelin)
+# zeppelin - Urban Airship library for Ruby [![StillMaintained Status](http://stillmaintained.com/CapnKernul/zeppelin.png)](http://stillmaintained.com/CapnKernul/zeppelin) [![Build Status](https://travis-ci.org/kern/zeppelin.png)](https://travis-ci.org/kern/zeppelin)
 
 Ruby client for the [Urban Airship](http://urbanairship.com) Push Notification
 API.
@@ -34,9 +34,9 @@ Check out the docs for more ways of querying the API.
 
 ## Resources ##
 
-* [GitHub Repository](https://github.com/CapnKernul/zeppelin)
-* [Documentation](http://rubydoc.info/github/CapnKernul/zeppelin)
-* [Issues](https://github.com/CapnKernul/zeppelin/issues)
+* [GitHub Repository](https://github.com/kern/zeppelin)
+* [Documentation](http://rubydoc.info/github/kern/zeppelin)
+* [Issues](https://github.com/kern/zeppelin/issues)
 
 ## License ##
 

--- a/zeppelin.gemspec
+++ b/zeppelin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Alexander Kern', 'James Herdman']
   s.email       = ['alex@kernul.com', 'james.herdman@me.com']
-  s.homepage    = 'https://github.com/CapnKernul/zeppelin'
+  s.homepage    = 'https://github.com/kern/zeppelin'
   s.summary     = %q{Urban Airship library for Ruby}
   s.description = %q{Ruby client for the Urban Airship Push Notification API}
 


### PR DESCRIPTION
The `stillmaintained` links are still referring to CapnKernul and they're still working. Not sure if the `stillmaintained` message is accurate, though.
