### PR TITLE
Add Faraday 0.9.0 compatiblity

### DIFF
--- a/lib/zeppelin/middleware.rb
+++ b/lib/zeppelin/middleware.rb
@@ -5,4 +5,9 @@ end
 
 require 'zeppelin/middleware/response_raise_error'
 
-Faraday.register_middleware :response, zeppelin_raise_error: Zeppelin::Middleware::ResponseRaiseError
+# For backwards compatibility with Faraday < 0.9
+if Faraday.respond_to?(:register_middleware)
+  Faraday.register_middleware :response, zeppelin_raise_error: Zeppelin::Middleware::ResponseRaiseError
+else
+  Faraday::Response.register_middleware zeppelin_raise_error: Zeppelin::Middleware::ResponseRaiseError
+end

--- a/zeppelin.gemspec
+++ b/zeppelin.gemspec
@@ -15,15 +15,12 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'zeppelin'
 
-  s.add_dependency 'faraday', '< 0.9.0'
+  s.add_dependency 'faraday'
   s.add_dependency 'faraday_middleware', '~> 0.9.0', '>= 0.9.0'
 
   s.add_development_dependency 'rspec', '~> 2.14.1', '>= 2.14.1'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'json'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
+  s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.require_paths = ['lib']
 end


### PR DESCRIPTION
I think I updated the middleware for Faraday 0.9.0, the specs pass, but I haven't used Faraday so I'm not sure if this is the only change needed. 
